### PR TITLE
Ability to detect long press on hyperlink

### DIFF
--- a/DemoApp/OSX/SEAppDelegate.m
+++ b/DemoApp/OSX/SEAppDelegate.m
@@ -185,7 +185,7 @@ static const CGFloat LINE_SPACING = 4.0f;
 
 #pragma mark -
 
-- (BOOL)textView:(SETextView *)aTextView clickedOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
+- (BOOL)textView:(SETextView *)aTextView didClickOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
 {
     NSString *text = link.object;
     if ([text hasPrefix:@"http"]) {
@@ -198,6 +198,11 @@ static const CGFloat LINE_SPACING = 4.0f;
         [[NSWorkspace sharedWorkspace] openURL:searchURL];
     }
     
+    return YES;
+}
+
+- (BOOL)textView:(SETextView *)aTextView didLongPressOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
+{
     return YES;
 }
 

--- a/DemoApp/iOS/SETimelineViewController.m
+++ b/DemoApp/iOS/SETimelineViewController.m
@@ -126,7 +126,7 @@ static const CGFloat FONT_SIZE = 14.0f;
 
 #pragma mark -
 
-- (BOOL)textView:(SETextView *)aTextView clickedOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
+- (BOOL)textView:(SETextView *)aTextView didClickOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
 {
     NSString *text = link.object;
     if ([text hasPrefix:@"http"]) {
@@ -143,6 +143,12 @@ static const CGFloat FONT_SIZE = 14.0f;
     
     return YES;
 }
+
+- (BOOL)textView:(SETextView *)aTextView didLongPressOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
+{
+    return YES;
+}
+
 
 #pragma mark -
 

--- a/DemoApp/iOS/SETweetViewController.m
+++ b/DemoApp/iOS/SETweetViewController.m
@@ -97,7 +97,7 @@ static const CGFloat FONT_SIZE = 16.0f;
 
 #pragma mark -
 
-- (BOOL)textView:(SETextView *)aTextView clickedOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
+- (BOOL)textView:(SETextView *)aTextView didClickOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex
 {
     NSString *text = link.object;
     if ([text hasPrefix:@"http"]) {

--- a/Lib/SETextView.h
+++ b/Lib/SETextView.h
@@ -54,6 +54,8 @@ typedef NS_ENUM(NSUInteger, SETextAttachmentDrawingOptions) {
 @property (strong, nonatomic, readonly) NSString *selectedText;
 @property (strong, nonatomic, readonly) NSString *selectedAttributedText;
 
+@property (nonatomic, assign) NSTimeInterval minimumLongPressDuration;
+
 - (id)initWithFrame:(CGRect)frame;
 
 + (CGRect)frameRectWithAttributtedString:(NSAttributedString *)attributedString
@@ -76,7 +78,8 @@ typedef NS_ENUM(NSUInteger, SETextAttachmentDrawingOptions) {
 @protocol SETextViewDelegate <NSObject>
 
 @optional
-- (BOOL)textView:(SETextView *)aTextView clickedOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex;
+- (BOOL)textView:(SETextView *)aTextView didClickOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex;
+- (BOOL)textView:(SETextView *)aTextView didLongPressOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex;
 - (void)textViewDidChangeSelection:(SETextView *)aTextView;
 - (void)textViewDidEndSelecting:(SETextView *)aTextView;
 


### PR DESCRIPTION
SETextView上でのリンクの長押しが知りたかったので追加しました.
タッチ/クリックが始まると同時に NSTimer をスタートさせる微妙なやり方ですが, [ここ](https://github.com/questbeat/SECoreTextView/blob/85f0ff1f00b2d035bed3f6840f0a175eedc0aab8/Lib/SETextView.m#L697-735)の実装が間違っていなければ特に問題ないかと思います.
iOS/Mac OS両方で動作確認しました.
## New Methods in SETextViewDelegate

```
- (BOOL)textView:(SETextView *)aTextView didLongPressOnLink:(SELinkText *)link atIndex:(NSUInteger)charIndex;
```

Tells the delegate that the link was long pressed in the specified text view.
## New Properties in SETextView
### Public

```
@property (nonatomic, assign) NSTimeInterval minimumLongPressDuration;
```

The minimum period fingers/mouse must press on the link to be recognized as long press.
### Private

@property (nonatomic, weak) NSTimer *longPressTimer;
@property (nonatomic, assign, getter = isLongPressing) BOOL longPressing;
