### PR TITLE
get first CTRunDelegate attribute (fix #18)

### DIFF
--- a/Lib/SETextView.m
+++ b/Lib/SETextView.m
@@ -2397,6 +2397,9 @@ static NSString * const PARAGRAPH_SEPARATOR = @"\u2029";
     if (index > 0) {
         attribute = [attributdString attribute:(id)kCTRunDelegateAttributeName atIndex:index - 1 effectiveRange:nil];
     }
+    else if ([attributdString length] > 0) {
+        attribute = [attributdString attribute:(id)kCTRunDelegateAttributeName atIndex:0 effectiveRange:nil];
+    }
 	if (NSMaxRange(range) > attributdString.length) {
 		return;
 	}


### PR DESCRIPTION
先頭が CTRunDelegate でそこに文字を挿入するとき、NSString として挿入しており CTRunDelegate 属性が延長されておかしくなるようです。
上記のケースでも NSAttributedString を新規生成して挿入するようにしました。
