### PR TITLE
fix #47

### DIFF
--- a/Lib/SECompatibility.h
+++ b/Lib/SECompatibility.h
@@ -12,7 +12,7 @@
 #import <UIKit/UIKit.h>
 
 @compatibility_alias NSView UIView;
-@compatibility_alias NSFont UIFont;
+#define NSFont UIFont
 @compatibility_alias NSColor UIColor;
 @compatibility_alias NSBezierPath UIBezierPath;
 @compatibility_alias NSImage UIImage;


### PR DESCRIPTION
Xcode 6.2でビルドが通らなくなってしまっていました。
iOS内部にどうやらNSFontがあるみたいです。
とりあえずの対応ですが、PureLayoutがPureLayoutDefines.hでしているようにSEFontなどを新しくdefineした方がいいのかもしれません。
https://github.com/smileyborg/PureLayout/blob/master/PureLayout/PureLayout/PureLayoutDefines.h