### PR TITLE
Fix to keep aspect ratio when dragging edge and support retina display

### DIFF
--- a/Examples/Mac/TwitterClient-Mac/TwitterClient-Mac.xcodeproj/project.pbxproj
+++ b/Examples/Mac/TwitterClient-Mac/TwitterClient-Mac.xcodeproj/project.pbxproj
@@ -64,7 +64,6 @@
 		1469DC6917F3613900ADDA7E /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		1469DC7117F3633400ADDA7E /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
 		14EDE30617F55A9800ABF2C6 /* SECoreTextView.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SECoreTextView.bundle; path = ../../../../Resources/SECoreTextView.bundle; sourceTree = "<group>"; };
-		14EDE30817F55AA100ABF2C6 /* NSMutableAttributedString+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableAttributedString+Helper.h"; path = "../../../../Lib/NSMutableAttributedString+Helper.h"; sourceTree = "<group>"; };
 		14EDE30A17F55AA100ABF2C6 /* SECompatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SECompatibility.h; path = ../../../../Lib/SECompatibility.h; sourceTree = "<group>"; };
 		14EDE30B17F55AA100ABF2C6 /* SECompatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SECompatibility.m; path = ../../../../Lib/SECompatibility.m; sourceTree = "<group>"; };
 		14EDE30C17F55AA100ABF2C6 /* SEConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SEConstants.h; path = ../../../../Lib/SEConstants.h; sourceTree = "<group>"; };
@@ -222,7 +221,6 @@
 				14EDE30D17F55AA100ABF2C6 /* SEConstants.m */,
 				14EDE30A17F55AA100ABF2C6 /* SECompatibility.h */,
 				14EDE30B17F55AA100ABF2C6 /* SECompatibility.m */,
-				14EDE30817F55AA100ABF2C6 /* NSMutableAttributedString+Helper.h */,
 				14EDE30617F55A9800ABF2C6 /* SECoreTextView.bundle */,
 			);
 			name = Lib;

--- a/Examples/iOS/RichTextEditor/RichTextEditor.xcodeproj/project.pbxproj
+++ b/Examples/iOS/RichTextEditor/RichTextEditor.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		14EDE30217F55A7C00ABF2C6 /* SETextSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 14EDE2F117F55A7C00ABF2C6 /* SETextSelectionView.m */; };
 		14EDE30317F55A7C00ABF2C6 /* SETextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 14EDE2F317F55A7C00ABF2C6 /* SETextView.m */; };
 		14EDE30517F55A8F00ABF2C6 /* SECoreTextView.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 14EDE30417F55A8F00ABF2C6 /* SECoreTextView.bundle */; };
+		D94F7A671AB685D200D96592 /* SEViewCaptureHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = D94F7A661AB685D200D96592 /* SEViewCaptureHelper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -152,7 +153,6 @@
 		1469DC7817F3770F00ADDA7E /* SEStampInputView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEStampInputView.m; sourceTree = "<group>"; };
 		1469DC7A17F3773D00ADDA7E /* SEInputAccessoryView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEInputAccessoryView.h; sourceTree = "<group>"; };
 		1469DC7B17F3773D00ADDA7E /* SEInputAccessoryView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEInputAccessoryView.m; sourceTree = "<group>"; };
-		14EDE2D417F55A7C00ABF2C6 /* NSMutableAttributedString+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableAttributedString+Helper.h"; path = "../../../../Lib/NSMutableAttributedString+Helper.h"; sourceTree = "<group>"; };
 		14EDE2D617F55A7C00ABF2C6 /* SECompatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SECompatibility.h; path = ../../../../Lib/SECompatibility.h; sourceTree = "<group>"; };
 		14EDE2D717F55A7C00ABF2C6 /* SECompatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SECompatibility.m; path = ../../../../Lib/SECompatibility.m; sourceTree = "<group>"; };
 		14EDE2D817F55A7C00ABF2C6 /* SEConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SEConstants.h; path = ../../../../Lib/SEConstants.h; sourceTree = "<group>"; };
@@ -184,6 +184,8 @@
 		14EDE2F217F55A7C00ABF2C6 /* SETextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SETextView.h; path = ../../../../Lib/SETextView.h; sourceTree = "<group>"; };
 		14EDE2F317F55A7C00ABF2C6 /* SETextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SETextView.m; path = ../../../../Lib/SETextView.m; sourceTree = "<group>"; };
 		14EDE30417F55A8F00ABF2C6 /* SECoreTextView.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SECoreTextView.bundle; path = ../../../../Resources/SECoreTextView.bundle; sourceTree = "<group>"; };
+		D94F7A651AB685D200D96592 /* SEViewCaptureHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SEViewCaptureHelper.h; path = ../../../../Lib/SEViewCaptureHelper.h; sourceTree = "<group>"; };
+		D94F7A661AB685D200D96592 /* SEViewCaptureHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEViewCaptureHelper.m; path = ../../../../Lib/SEViewCaptureHelper.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -276,13 +278,14 @@
 				14EDE2EB17F55A7C00ABF2C6 /* SETextMagnifierCaret.m */,
 				14EDE2EC17F55A7C00ABF2C6 /* SETextMagnifierRanged.h */,
 				14EDE2ED17F55A7C00ABF2C6 /* SETextMagnifierRanged.m */,
+				D94F7A651AB685D200D96592 /* SEViewCaptureHelper.h */,
+				D94F7A661AB685D200D96592 /* SEViewCaptureHelper.m */,
 				14EDE2E217F55A7C00ABF2C6 /* SETextEditingCaret.h */,
 				14EDE2E317F55A7C00ABF2C6 /* SETextEditingCaret.m */,
 				14EDE2D817F55A7C00ABF2C6 /* SEConstants.h */,
 				14EDE2D917F55A7C00ABF2C6 /* SEConstants.m */,
 				14EDE2D617F55A7C00ABF2C6 /* SECompatibility.h */,
 				14EDE2D717F55A7C00ABF2C6 /* SECompatibility.m */,
-				14EDE2D417F55A7C00ABF2C6 /* NSMutableAttributedString+Helper.h */,
 				14EDE30417F55A8F00ABF2C6 /* SECoreTextView.bundle */,
 			);
 			name = Lib;
@@ -486,6 +489,7 @@
 				14EDE2F517F55A7C00ABF2C6 /* SECompatibility.m in Sources */,
 				1469DC7C17F3773E00ADDA7E /* SEInputAccessoryView.m in Sources */,
 				14EDE2F817F55A7C00ABF2C6 /* SELinkText.m in Sources */,
+				D94F7A671AB685D200D96592 /* SEViewCaptureHelper.m in Sources */,
 				14EDE30017F55A7C00ABF2C6 /* SETextMagnifierRanged.m in Sources */,
 				14EDE30317F55A7C00ABF2C6 /* SETextView.m in Sources */,
 			);

--- a/Examples/iOS/TwitterClient-iOS/TwitterClient-iOS.xcodeproj/project.pbxproj
+++ b/Examples/iOS/TwitterClient-iOS/TwitterClient-iOS.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		1469DBE717F35E3200ADDA7E /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1469DBE617F35E3200ADDA7E /* Twitter.framework */; };
 		1469DBE917F35E4300ADDA7E /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1469DBE817F35E4300ADDA7E /* Accounts.framework */; };
 		1469DBEB17F35E5100ADDA7E /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1469DBEA17F35E5100ADDA7E /* Social.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		D94F7A641AB685C700D96592 /* SEViewCaptureHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = D94F7A631AB685C700D96592 /* SEViewCaptureHelper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -113,6 +114,8 @@
 		1469DBE617F35E3200ADDA7E /* Twitter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Twitter.framework; path = System/Library/Frameworks/Twitter.framework; sourceTree = SDKROOT; };
 		1469DBE817F35E4300ADDA7E /* Accounts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accounts.framework; path = System/Library/Frameworks/Accounts.framework; sourceTree = SDKROOT; };
 		1469DBEA17F35E5100ADDA7E /* Social.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Social.framework; path = System/Library/Frameworks/Social.framework; sourceTree = SDKROOT; };
+		D94F7A621AB685C700D96592 /* SEViewCaptureHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SEViewCaptureHelper.h; path = ../../../../Lib/SEViewCaptureHelper.h; sourceTree = "<group>"; };
+		D94F7A631AB685C700D96592 /* SEViewCaptureHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEViewCaptureHelper.m; path = ../../../../Lib/SEViewCaptureHelper.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,6 +251,8 @@
 				1469DBBB17F35DC100ADDA7E /* SEConstants.m */,
 				1469DBB817F35DC100ADDA7E /* SECompatibility.h */,
 				1469DBB917F35DC100ADDA7E /* SECompatibility.m */,
+				D94F7A621AB685C700D96592 /* SEViewCaptureHelper.h */,
+				D94F7A631AB685C700D96592 /* SEViewCaptureHelper.m */,
 				14178A8D17F3AB8800C70E04 /* SECoreTextView.bundle */,
 			);
 			name = Lib;
@@ -338,6 +343,7 @@
 				1469DBDB17F35DC100ADDA7E /* SESelectionGrabber.m in Sources */,
 				1469DBDC17F35DC100ADDA7E /* SETextAttachment.m in Sources */,
 				1469DBDD17F35DC100ADDA7E /* SETextEditingCaret.m in Sources */,
+				D94F7A641AB685C700D96592 /* SEViewCaptureHelper.m in Sources */,
 				1469DBDE17F35DC100ADDA7E /* SETextGeometry.m in Sources */,
 				1469DBDF17F35DC100ADDA7E /* SETextInput.m in Sources */,
 				1469DBE017F35DC100ADDA7E /* SETextLayout.m in Sources */,

--- a/Lib/SETextMagnifierCaret.m
+++ b/Lib/SETextMagnifierCaret.m
@@ -10,6 +10,7 @@
 
 #if TARGET_OS_IPHONE
 #import "SETextMagnifierCaret.h"
+#import "SEViewCaptureHelper.h"
 
 @interface SETextMagnifierCaret ()
 {
@@ -126,36 +127,24 @@
 
 - (void)drawRect:(CGRect)rect
 {
-    UIGraphicsBeginImageContext(self.magnifyToView.bounds.size);
-    [self.magnifyToView.layer renderInContext:UIGraphicsGetCurrentContext()];
-    UIImage *captureImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    CGImageRef captureImageRef = captureImage.CGImage;
+    UIImage *captureImage = [SEViewCaptureHelper captureView:self.magnifyToView
+                                                      center:self.touchPoint
+                                                        size:self.mask.size
+                                                       scale:1.2f];
 
-    CGFloat scale = 1.2f;
-    CGRect box = CGRectMake(ceilf(self.touchPoint.x - self.mask.size.width / scale / 2),
-                            ceilf(self.touchPoint.y - self.mask.size.height / scale / 2),
-                            ceilf(self.mask.size.width / scale),
-                            ceilf(self.mask.size.height / scale));
-    
-    CGImageRef subImage = CGImageCreateWithImageInRect(captureImageRef, box);
-    CGImageRef maskedImage = CGImageCreateWithMask(subImage, _maskRef);
+    CGImageRef maskedImage = CGImageCreateWithMask(captureImage.CGImage, _maskRef);
 
     CGContextRef context = UIGraphicsGetCurrentContext();
-
-    CGAffineTransform xform = CGAffineTransformMake(1.0,  0.0,
-                                                    0.0, -1.0,
-                                                    0.0,  0.0);
-    CGContextConcatCTM(context, xform);
     
-    CGRect area = CGRectMake(0, 0, self.mask.size.width, -self.mask.size.height);
+    CGContextScaleCTM(context, 1, -1);
+    CGContextTranslateCTM(context, 0, -self.mask.size.height);
+    
+    CGRect area = (CGRect){ CGPointZero, self.mask.size };
     
     CGContextDrawImage(context, area, self.loupeFrame.CGImage);
     CGContextDrawImage(context, area, maskedImage);
     CGContextDrawImage(context, area, self.loupe.CGImage);
     
-    CGImageRelease(subImage);
     CGImageRelease(maskedImage);
 }
 

--- a/Lib/SEViewCaptureHelper.h
+++ b/Lib/SEViewCaptureHelper.h
@@ -1,0 +1,22 @@
+//
+//  SEViewCaptureHelper.h
+//  SECoreTextView-iOS
+//
+//  Created by ryohey on 2015/03/16.
+//  Copyright (c) 2015年 kishikawa katsumi. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+
+@interface SEViewCaptureHelper : NSObject
+
+/// Capturing UIView to UIImage around center
++ (UIImage *)captureView:(UIView *)view
+                  center:(CGPoint)center
+                    size:(CGSize)size
+                   scale:(CGFloat)scale;
+
+@end
+#endif

--- a/Lib/SEViewCaptureHelper.h
+++ b/Lib/SEViewCaptureHelper.h
@@ -10,6 +10,8 @@
 
 #if TARGET_OS_IPHONE
 
+#import <UIKit/UIKit.h>
+
 @interface SEViewCaptureHelper : NSObject
 
 /// Capturing UIView to UIImage around center

--- a/Lib/SEViewCaptureHelper.m
+++ b/Lib/SEViewCaptureHelper.m
@@ -1,0 +1,36 @@
+//
+//  SEViewCaptureHelper.m
+//  SECoreTextView-iOS
+//
+//  Created by ryohey on 2015/03/16.
+//  Copyright (c) 2015年 kishikawa katsumi. All rights reserved.
+//
+
+#import "SEViewCaptureHelper.h"
+
+#if TARGET_OS_IPHONE
+
+@implementation SEViewCaptureHelper
+
++ (UIImage *)captureView:(UIView *)view
+                  center:(CGPoint)center
+                    size:(CGSize)size
+                   scale:(CGFloat)scale {
+    
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
+    
+    CGFloat x = ceilf(center.x - size.width / scale / 2);
+    CGFloat y = ceilf(center.y - size.height / scale / 2);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextScaleCTM(context, scale, scale);
+    CGContextTranslateCTM(context, -x, -y);
+    
+    [view.layer renderInContext:UIGraphicsGetCurrentContext()];
+    UIImage *captureImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return captureImage;
+}
+
+@end
+#endif


### PR DESCRIPTION
SECoreTextView をいつも使わせて頂いています。大変便利で、必要不可欠になっています。
ありがとうございます。

ルーペが画面端に寄ると内容が伸びていたのと、キャプチャするスケールが小さくてぼやけていたので、修正致しました。

### 変更内容

- `SETextMagnifierCaret` と `SETextMagnifierRanged` の View をキャプチャする処理を `SEViewCaptureHelper` にまとめました
- キャプチャする際に `UIGraphicsBeginImageContextWithOptions` を使ってスケールをデバイスに合わせました
- ルーペが画面端に寄ると内容が伸びていたのを修正しました
- 削除されたファイル `NSMutableAttributedString+Helper.h`, `NSMutableAttributedString+Helper.m` をプロジェクトから除去しました

#### 修正前

![ios simulator screen shot 2015 03 16 12 42 14](https://cloud.githubusercontent.com/assets/5355966/6660335/1c0dfa72-cbda-11e4-9e25-7ae1190a4d74.png)

#### 修正後

![ios simulator screen shot 2015 03 16 12 41 31](https://cloud.githubusercontent.com/assets/5355966/6660339/214089f6-cbda-11e4-9506-ea32a4f847eb.png)
